### PR TITLE
Add redirect from localized homepage

### DIFF
--- a/site/pages/[locale]/index.js
+++ b/site/pages/[locale]/index.js
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
+import { defaultLocale, locales } from '../../navigation'
+import { homepageRedirect } from '../index'
+
+function HomePage() {
+  const router = useRouter()
+
+  useEffect(
+    function redirectHomepage() {
+      const [language] = navigator.language.split('-')
+      const enabledLanguage = locales.includes(language)
+      router.replace(
+        `/${enabledLanguage ? language : defaultLocale}${homepageRedirect}`
+      )
+    },
+    [router]
+  )
+  return null
+}
+
+export default HomePage

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -1,11 +1,13 @@
 import { useRedirectToDefaultLocale } from '../hooks/useRedirectToDefaultLocale'
 import { defaultLocale, locales } from '../navigation'
 
+export const homepageRedirect = '/merkle-claims'
+
 function HomePage() {
   useRedirectToDefaultLocale({
     defaultLocale,
     locales,
-    redirectPage: '/merkle-claims'
+    redirectPage: homepageRedirect
   })
   return null
 }


### PR DESCRIPTION
## Summary

<!--- Provide a general summary of your changes in the Title above -->
This adds a redirect from `/en/` to `/en/merkle-claims`. This is in case the user directly enters `/en` or clicks the logo.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
