### PR TITLE
Fix redirect from localized homepage

### DIFF
--- a/site/pages/[locale]/index.js
+++ b/site/pages/[locale]/index.js
@@ -20,4 +20,5 @@ function HomePage() {
   return null
 }
 
+export { getStaticProps, getStaticPaths } from '../../utils/staticProps'
 export default HomePage


### PR DESCRIPTION
## Summary

<!--- Provide a general summary of your changes in the Title above -->
This fixes the issue with the homepage when accessing directly to `/en` (or any other supported language).

## Description

<!--- Describe your changes in detail -->
We were missing the `getStaticProps` and `getStaticPaths` in the page. It now generates an index.html file inside `/[locale]` which solves the problem.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and reviewed output files. Served and manually accesed `/en/`, it should redirect to `/en/merkle-claims` and it did.

## Screenshots (if appropriate):
<img width="267" alt="Captura de pantalla 2024-04-17 a la(s) 10 17 09" src="https://github.com/purefinance/pure.finance/assets/1864435/b4de7437-59c5-41bb-a9b6-88aefb1350ae">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
