### PR TITLE
Allow overriding Button case

### DIFF
--- a/site/components/Button.js
+++ b/site/components/Button.js
@@ -7,7 +7,13 @@ const Button = function ({
   ...props
 }) {
   const boxStyle = `py-3 rounded-xl ${width} focus:outline-none`
-  const textStyle = 'text-center text-base text-white capitalize'
+  const textCase = className
+    .split(' ')
+    .filter(Boolean)
+    .some(c => ['lowercase', 'normal-case', 'uppercase'].includes(c))
+    ? ''
+    : 'capitalize'
+  const textStyle = `text-center text-base text-white ${textCase}`
   const stateStyle = disabled
     ? 'bg-gray-200 cursor-not-allowed'
     : 'bg-black hover:bg-gray-800'

--- a/site/pages/[locale]/wrap-eth.js
+++ b/site/pages/[locale]/wrap-eth.js
@@ -57,7 +57,7 @@ const WrapUnwrapEth = function () {
 
   const [errorMessage, setErrorMessage] = useTemporalMessage()
   const [successMessage, setSuccessMessage] = useTemporalMessage()
-  const { nativeTokenSymbol = 'hETH' } = findByChainId(chainId)
+  const { nativeTokenSymbol = 'ETH' } = findByChainId(chainId)
 
   const isValidNumber =
     value !== '' &&
@@ -184,7 +184,7 @@ const WrapUnwrapEth = function () {
             />
           </div>
           <Button
-            className="mt-7.5 uppercase"
+            className="mt-7.5 normal-case"
             disabled={
               !active ||
               !isValidNumber ||


### PR DESCRIPTION
## Summary

If a case is specified for the `Button` component, override the default `capitalize` class.

## Screenshots

<img width="423" alt="image" src="https://github.com/hemilabs/pure.finance/assets/2621975/325e4aa4-0630-4a5b-9def-89bd1baaf6db">
