### PR TITLE
Fixed token input symbol and address overlap

### DIFF
--- a/site/components/Input.js
+++ b/site/components/Input.js
@@ -3,7 +3,7 @@ import React from 'react'
 import SvgContainer from './svg/SvgContainer'
 
 const commonInputStyles =
-  'text-base px-4 py-3 rounded-xl bg-white placeholder-slate-400 border placeholder-capitalize'
+  'text-base bg-white placeholder-slate-400 placeholder-capitalize'
 
 export const InputTitle = ({ children }) => (
   <label className="text-md text-slate-500 mb-2.5 block">{children}</label>
@@ -28,9 +28,9 @@ const SuffixedInput = ({ suffix, ...props }) => (
 
 const Caption = ({ caption, captionColor }) =>
   caption && (
-    <div className="absolute flex items-center gap-1">
+    <div className="bg-slate-50 -mx-4 -my-3 flex items-center justify-center gap-1 rounded-r-xl border-l px-4">
       <CaptionIcon captionColor={captionColor} />
-      <p className={`pr-4 text-sm ${captionColor}`}>{caption}</p>
+      <p className={`text-center text-base ${captionColor}`}>{caption}</p>
     </div>
   )
 
@@ -56,7 +56,7 @@ const Input = ({
   captionColor,
   ...props
 }) => (
-  <div className={`mb-6 flex w-full items-center justify-end ${className}`}>
+  <div className={`mb-6 flex w-full rounded-xl border px-4 py-3 ${className}`}>
     {suffix ? (
       <SuffixedInput suffix={suffix} {...props} placeholder={title} />
     ) : (

--- a/site/hooks/useTokenInput.js
+++ b/site/hooks/useTokenInput.js
@@ -54,7 +54,7 @@ const useTokenInput = function (address, onChange = () => {}, allowAnyAddress) {
           .getInfo()
           .then(function (info) {
             onChange(info)
-            setTokenName(info.name)
+            setTokenName(info.symbol)
           })
           .catch(function () {
             if (allowAnyAddress) {


### PR DESCRIPTION
Closes https://github.com/hemilabs/pure.finance/issues/50

This PR includes:
- Fixes on token input layout to avoid the symbol to overlap the token address;

Here is a screenshot showing the fix:
<img width="817" alt="Captura de Tela 2024-12-02 às 16 50 16" src="https://github.com/user-attachments/assets/b37aef5e-c7ae-4146-b8ba-ac755891a0a8">

However, the same text is used to show errors like the following screenshot:
<img width="817" alt="Captura de Tela 2024-12-02 às 16 51 17" src="https://github.com/user-attachments/assets/d6efeb6b-d22d-4754-a421-0e7814622d59">

@dvnahuel What should I do about the error messages? Please let me know in the PR comments.