### PR TITLE
Fixed claim button to be disable when holding is not claimable

### DIFF
--- a/site/pages/[locale]/merkle-claims.js
+++ b/site/pages/[locale]/merkle-claims.js
@@ -142,12 +142,11 @@ function MerkleClaims() {
             toFixed(fromUnit(holding.amount, holding.token.decimals), 6)
           }
         />
-        {/* TODO disable the button if not claimable! */}
         <div className="mt-8">
           <CallToAction>
             <Button
               className="flex justify-center"
-              disabled={!claimID}
+              disabled={!holding.isClaimable}
               onClick={handleClaimSubmit}
             >
               {t('claim')}


### PR DESCRIPTION
Closes https://github.com/hemilabs/pure.finance/issues/51

This PR includes:
- Fixed claim button to be disable when holding is not claimable.

Screenshot:
<img width="825" alt="Captura de Tela 2024-12-11 às 11 30 56" src="https://github.com/user-attachments/assets/5fbd5c1c-9515-4d85-a22f-4e42d6bd7756" />
