### PR TITLE
Enable ENS support in Hemi

### DIFF
--- a/site/hooks/useTokenInput.js
+++ b/site/hooks/useTokenInput.js
@@ -1,11 +1,11 @@
 import { useWeb3React } from '@web3-react/core'
-import { util } from 'erc-20-lib'
 import debounce from 'lodash.debounce'
 import { useTranslations } from 'next-intl'
 import { useCallback, useContext, useEffect, useState } from 'react'
-import { isAddress, isHexStrict } from 'web3-utils'
+import { isHexStrict } from 'web3-utils'
 
 import PureContext from '../components/context/Pure'
+import { resolveAddress } from '../utils/resolveAddress'
 
 const useTokenInput = function (address, onChange = () => {}, allowAnyAddress) {
   const t = useTranslations()
@@ -27,15 +27,7 @@ const useTokenInput = function (address, onChange = () => {}, allowAnyAddress) {
     debounce(function (value) {
       setTokenError('')
 
-      const addressPromise = isAddress(value)
-        ? Promise.resolve(value)
-        : Promise.resolve(
-            util.tokenAddress(value, chainId) ||
-              library.eth.ens.getAddress(value)
-          ).catch(function (err) {
-            console.log(err)
-            return null
-          })
+      const addressPromise = resolveAddress(library, value)
 
       // eslint-disable-next-line promise/catch-or-return
       addressPromise.then(function (addressFound) {

--- a/site/hooks/useTokenInput.js
+++ b/site/hooks/useTokenInput.js
@@ -16,12 +16,15 @@ const useTokenInput = function (address, onChange = () => {}, allowAnyAddress) {
   const [tokenError, setTokenError] = useState('')
   const [tokenName, setTokenName] = useState('')
 
-  useEffect(() => {
-    onChange(null)
-    setTokenAddress('')
-    setTokenName('')
-    setTokenError('')
-  }, [active, chainId])
+  useEffect(
+    function () {
+      onChange(null)
+      setTokenAddress('')
+      setTokenName('')
+      setTokenError('')
+    },
+    [active, chainId, onChange]
+  )
 
   const delayedGetTokenInfo = useCallback(
     debounce(function (value) {
@@ -58,23 +61,26 @@ const useTokenInput = function (address, onChange = () => {}, allowAnyAddress) {
           })
       })
     }, 1000),
-    [erc20]
+    [allowAnyAddress, erc20, library, onChange, t]
   )
 
-  const handleChange = function (e) {
-    const { value } = e.target
+  const handleChange = useCallback(
+    function (e) {
+      const { value } = e.target
 
-    const re = /^[0-9a-zA-Z.]*$/
-    if (!re.test(e.target.value)) {
-      return
-    }
+      const re = /^[0-9a-zA-Z.]*$/
+      if (!re.test(e.target.value)) {
+        return
+      }
 
-    setTokenAddress(value)
-    setTokenName('')
-    setTokenError('')
+      setTokenAddress(value)
+      setTokenName('')
+      setTokenError('')
 
-    delayedGetTokenInfo(value)
-  }
+      delayedGetTokenInfo(value)
+    },
+    [delayedGetTokenInfo]
+  )
 
   useEffect(
     function () {
@@ -83,7 +89,7 @@ const useTokenInput = function (address, onChange = () => {}, allowAnyAddress) {
       }
       handleChange({ target: { value: address } })
     },
-    [address, erc20]
+    [address, erc20, handleChange]
   )
 
   return {

--- a/site/utils/resolveAddress.js
+++ b/site/utils/resolveAddress.js
@@ -1,0 +1,38 @@
+import { util } from 'erc-20-lib'
+
+const extraEnsRegistries = {
+  43111: '0x099Fee7f2EF53eB7CCC0e465a32f3aEfa8D703C5' // getheminames.me
+}
+
+/**
+ * Try resolving a string to an address.
+ *
+ * If the value is already an address, it will be returned as is. If the value
+ * is a token symbol, it will be resolved to an address using the token list. If
+ * the value is an ENS name, it will be resolved to an address using the ENS
+ * registry. If the value cannot be resolved, null will be returned.
+ *
+ * @param {object} web3
+ * @param {string} string
+ * @returns {Promise<string|null>}
+ */
+export async function resolveAddress(web3, string) {
+  if (web3.utils.isAddress(string)) {
+    return string
+  }
+
+  const chainId = await web3.eth.getChainId()
+  const tokenAddress = util.tokenAddress(string, chainId)
+  if (tokenAddress) {
+    return tokenAddress
+  }
+
+  try {
+    web3.eth.ens.registryAddress =
+      web3.eth.ens.registryAddress || extraEnsRegistries[chainId]
+    return web3.eth.ens.getAddress(string)
+  } catch (err) {
+    console.error(err) // eslint-disable-line no-console
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

<!--- Provide a general summary of your changes in the Title above -->

ENS is now supported in Hemi mainnet through the registry deployed by [getheminames.me](https://www.getheminames.me/).

While ZNS is another option for ENS support, they did not deploy any registry contract yet.

## Related Issue

Closes #22

